### PR TITLE
fix clangr

### DIFF
--- a/.bash_cpp
+++ b/.bash_cpp
@@ -33,8 +33,9 @@ clangv() {
 # this is useful for quick debugging and editing
 # usage: same as clangv
 clangr() {
-	echo clangv "$@" && ./"$1${2+.}${2:-}";
-	clangv "$@" && ./"$1${2+.}${2:-}";
+	clangv "$@";
+	echo ./"$1${2+.}${2:-}";
+	./"$1${2+.}${2:-}";
 }
 
 


### PR DESCRIPTION
clangr was running the executable twice.
The first time it ran was here (since these are actually two different commands): `echo clangv "$@" && ./"$1${2+.}${2:-}";`
...and the second time was of course here: `clangv "$@" && ./"$1${2+.}${2:-}";`
This pull request changes clangr to the desired behavior, I think.