### PR TITLE
added cds command to .bash_nav

### DIFF
--- a/.bash_nav
+++ b/.bash_nav
@@ -27,7 +27,7 @@ cds() {
     elif [ $# -ge 2 ] && [ $1 = "-" ]; then
         local args=( ${@:2} )
         eval "rm ${args[@]/#/"~/.short/"}"
-    elif [ $# -eq 0 ] || [ -d ./$1 ] || [ $1 = "-" ]; then
+    elif [ $# -eq 0 ] || [ -d $1 ] || [ $1 = "-" ]; then
         cd "$@"
     elif [ -d "$(realpath ~/.short/$1)" ]; then
         cd -P ~/.short/$1

--- a/.bash_nav
+++ b/.bash_nav
@@ -22,7 +22,7 @@ cds() {
         ls ~/.short/
     elif [ $# -eq 2 ] && [ $1 = "+" ]; then
         if [ $2 != "-" ]; then
-            ln -s "$PWD" "$HOME/.short/$2"
+            ln -sfn "$PWD" "$HOME/.short/$2"
         fi
     elif [ $# -ge 2 ] && [ $1 = "-" ]; then
         local args=( ${@:2} )

--- a/.bash_nav
+++ b/.bash_nav
@@ -11,26 +11,28 @@ alias srcbash='source ~/.bashrc'
 # ---This alias effectively creates a bookmarking app---
 # it adds global symlink shortcuts for use with the 'cds' command
 # ex: 'cds studycloud' will run 'cd -P ~/.short/studycloud'
-# to add a shortcut: go to the target directory and run 'cds + <shortcut_name>'
-# to remove a shortcut: run 'cds - <shortcut_name>'
+# to add a shortcut: go to the target directory and run 'cds + <shortcut_name>' or 'cds + .' to use the current directory name
+# to remove a shortcut: run 'cds - <shortcut_name>' (you can also tack on multiple shortcut names separated by spaces)
+# to list your shortcuts: run 'cds .'
 cds() {
     if [ ! -d ~/.short ]; then
         mkdir ~/.short
     fi
-    if [ $# -eq 0 ]; then
+    if [ $# -eq 1 ] && [ $1 = "." ]; then
         ls ~/.short/
     else
-        if [ $1 = "+" ]; then
+        if [ $# -eq 2 ] && [ $1 = "+" ]; then
             ln -s "$PWD" "$HOME/.short/$2"
-        elif [ $1 = "-" ] && [ $# -eq 2 ] && [ -L ~/.short/$2 ]; then
-            rm ~/.short/$2
+        elif [ $# -ge 2 ] && [ $1 = "-" ]; then
+            local args=( ${@:2} )
+            eval "rm ${args[@]/#/"~/.short/"}"
         else
-            if [ -d ./$1 ] || [ $1 = "-" ]; then
-                cd $1
-            elif [ -L ~/.short/$1 ]; then
+            if [ $# -eq 0 ] || [ -d ./$1 ] || [ $1 = "-" ]; then
+                cd "$@"
+            elif [ -d "$(realpath ~/.short/$1)" ]; then
                 cd -P ~/.short/$1
             else
-                echo "error: that directory or shortcut doesn't exist"
+                echo "cd: $1: No such file or directory"
             fi
         fi
     fi

--- a/.bash_nav
+++ b/.bash_nav
@@ -22,7 +22,7 @@ cds() {
     else
         if [ $1 = "+" ]; then
             ln -s "$PWD" "$HOME/.short/$2"
-        elif [ $1 = "-" ] && [ $# -eq 2 ]; then
+        elif [ $1 = "-" ] && [ $# -eq 2 ] && [ -L ~/.short/$2 ]; then
             rm ~/.short/$2
         else
             if [ -d ./$1 ] || [ $1 = "-" ]; then

--- a/.bash_nav
+++ b/.bash_nav
@@ -7,3 +7,28 @@ alias desk='cd /mnt/c/Users/gsera/Desktop'
 # source bash
 
 alias srcbash='source ~/.bashrc'
+
+# ---This alias effectively creates a bookmarking app---
+# it adds global symlink shortcuts for use with the 'cds' command
+# ex: 'cds studycloud' will run 'cd -P ~/.short/studycloud'
+# to add a shortcut: go to the target directory and run 'cds + <shortcut_name>'
+# to remove a shortcut: run 'cds - <shortcut_name>'
+cds() {
+    if [ ! -d ~/.short ]; then
+        mkdir ~/.short
+    fi
+    if [ $1 = "+" ]; then
+        ln -s "$PWD" "$HOME/.short/$2"
+    elif [ $1 = "-" ]; then
+        rm ~/.short/$2
+    else
+        if [ -L ~/.short/$1 ]; then
+            cd -P ~/.short/$1
+        elif [ -d ./$1 ]; then
+            # this code is here because I often use cds instead of cd by mistake
+            cd $1
+        else
+            echo "error: that shortcut or directory doesn't exist"
+        fi
+    fi
+}

--- a/.bash_nav
+++ b/.bash_nav
@@ -20,20 +20,18 @@ cds() {
     fi
     if [ $# -eq 1 ] && [ $1 = "." ]; then
         ls ~/.short/
-    else
-        if [ $# -eq 2 ] && [ $1 = "+" ]; then
+    elif [ $# -eq 2 ] && [ $1 = "+" ]; then
+        if [ $2 != "-" ]; then
             ln -s "$PWD" "$HOME/.short/$2"
-        elif [ $# -ge 2 ] && [ $1 = "-" ]; then
-            local args=( ${@:2} )
-            eval "rm ${args[@]/#/"~/.short/"}"
-        else
-            if [ $# -eq 0 ] || [ -d ./$1 ] || [ $1 = "-" ]; then
-                cd "$@"
-            elif [ -d "$(realpath ~/.short/$1)" ]; then
-                cd -P ~/.short/$1
-            else
-                echo "cd: $1: No such file or directory"
-            fi
         fi
+    elif [ $# -ge 2 ] && [ $1 = "-" ]; then
+        local args=( ${@:2} )
+        eval "rm ${args[@]/#/"~/.short/"}"
+    elif [ $# -eq 0 ] || [ -d ./$1 ] || [ $1 = "-" ]; then
+        cd "$@"
+    elif [ -d "$(realpath ~/.short/$1)" ]; then
+        cd -P ~/.short/$1
+    else
+        echo "cd: $1: No such file or directory"
     fi
 }

--- a/.bash_nav
+++ b/.bash_nav
@@ -22,10 +22,10 @@ cds() {
     else
         if [ $1 = "+" ]; then
             ln -s "$PWD" "$HOME/.short/$2"
-        elif [ $1 = "-" ]; then
+        elif [ $1 = "-" ] && [ $# -eq 2 ]; then
             rm ~/.short/$2
         else
-            if [ -d ./$1 ]; then
+            if [ -d ./$1 ] || [ $1 = "-" ]; then
                 cd $1
             elif [ -L ~/.short/$1 ]; then
                 cd -P ~/.short/$1

--- a/.bash_nav
+++ b/.bash_nav
@@ -18,16 +18,16 @@ cds() {
     if [ ! -d ~/.short ]; then
         mkdir ~/.short
     fi
-    if [ $# -eq 1 ] && [ $1 = "." ]; then
+    if [ $# -eq 1 ] && [ "$1" = "." ]; then
         ls ~/.short/
-    elif [ $# -eq 2 ] && [ $1 = "+" ]; then
-        if [ $2 != "-" ]; then
+    elif [ $# -eq 2 ] && [ "$1" = "+" ]; then
+        if [ "$2" != "-" ]; then
             ln -sfn "$PWD" "$HOME/.short/$2"
         fi
-    elif [ $# -ge 2 ] && [ $1 = "-" ]; then
+    elif [ $# -ge 2 ] && [ "$1" = "-" ]; then
         local args=( ${@:2} )
         eval "rm ${args[@]/#/"~/.short/"}"
-    elif [ $# -eq 0 ] || [ -d $1 ] || [ $1 = "-" ]; then
+    elif [ $# -eq 0 ] || [ -d "$1" ] || [ "$1" = "-" ]; then
         cd "$@"
     elif [ -d "$(realpath ~/.short/$1)" ]; then
         cd -P ~/.short/$1

--- a/.bash_nav
+++ b/.bash_nav
@@ -17,18 +17,21 @@ cds() {
     if [ ! -d ~/.short ]; then
         mkdir ~/.short
     fi
-    if [ $1 = "+" ]; then
-        ln -s "$PWD" "$HOME/.short/$2"
-    elif [ $1 = "-" ]; then
-        rm ~/.short/$2
+    if [ $# -eq 0 ]; then
+        ls ~/.short/
     else
-        if [ -L ~/.short/$1 ]; then
-            cd -P ~/.short/$1
-        elif [ -d ./$1 ]; then
-            # this code is here because I often use cds instead of cd by mistake
-            cd $1
+        if [ $1 = "+" ]; then
+            ln -s "$PWD" "$HOME/.short/$2"
+        elif [ $1 = "-" ]; then
+            rm ~/.short/$2
         else
-            echo "error: that shortcut or directory doesn't exist"
+            if [ -d ./$1 ]; then
+                cd $1
+            elif [ -L ~/.short/$1 ]; then
+                cd -P ~/.short/$1
+            else
+                echo "error: that directory or shortcut doesn't exist"
+            fi
         fi
     fi
 }


### PR DESCRIPTION
Not sure if you wanted this command I wrote, but I thought I'd create the pull request anyway!

The cds command allows you to create shortcuts in your bash. It's my version of cd with the added functionality of **s**hortcuts.
These shortcuts allow you to jump to a previously bookmarked directory by typing `cds <shortcut_name>` no matter where you are. You can create a shortcut by typing `cds + <shortcut_name>` in the directory that you want to bookmark. This will also override any existing shortcuts with the same name. You can delete a bookmark by typing `cds - <shortcut_name>` anywhere. You can list all available shortcuts by running `cds .`.
It also has almost all the functionality of the regular `cd` command. I've actually aliased `cd` to `cds` on my local computer and have so far encountered little errors (except for issues #12 and #13). (As of the writing of this pull request, I recommend that y'all don't replace `cd` with `cds` until more of the kinks have been worked out.)

So why do I use these shortcuts instead of bash aliases? The cds command lets me create and delete shortcuts really quickly. No need to navigate to your .bash_nav file, open vim, copy and paste the path, and then source bash. I can create shortcuts that I'll only use for the next two minutes. I guess there's also the benefit of this being user-friendly (especially for beginners); you don't need to know how to create bash aliases to create cd shortcuts.