### PR TITLE
cds - fixes for tab completions and realpath dependency

### DIFF
--- a/.bash_cds
+++ b/.bash_cds
@@ -1,4 +1,3 @@
-ABSPATH="$HOME/.myaliases" # delete this line when the code gets merged
 # ---This alias effectively creates a bookmarking app---
 # it adds global symlink shortcuts for use with the 'cds' command
 # ex) 'cds studycloud' will run 'cd -P ~/.myaliases/.short/studycloud'

--- a/.bash_cds
+++ b/.bash_cds
@@ -44,13 +44,6 @@ _cds() {
             _cd
             temp_reply=( "${temp_reply[@]/%//}" ) # append a slash to cds's completions
         fi
-        # if the first parameter to cds is "-"
-        if [ "${COMP_WORDS[1]}" = "-" ]; then
-            # remove any shortcut names that have already been typed from the completions
-            for shortcut in "${COMP_WORDS[@]:2}"; do
-                echo $shortcut
-            done
-        fi
         COMPREPLY+=( "${temp_reply[@]}" )
     # tab completion for 'cds /[tab]', 'cds <letter(s)>/[tab]', 'cds <letter(s)>/<letter(s)>/[tab], or some variation with a slash
     # needs to go find subdirectories

--- a/.bash_cds
+++ b/.bash_cds
@@ -21,7 +21,7 @@ cds() {
         eval "rm ${args[@]/#/"$SHORT_PATH/"}"
     elif [ $# -eq 0 ] || [ -d "$1" ] || [ "$1" = "-" ]; then
         cd "$@"
-    elif [ -d "$($ABSPATH/realpath $SHORT_PATH/$1 2>/dev/null)" ]; then
+    elif [ -d "$SHORT_PATH/$1" ]; then
         cd -P "$SHORT_PATH/$1"
     else
         echo "cd: $1: No such file or directory"

--- a/.bash_cds
+++ b/.bash_cds
@@ -37,7 +37,7 @@ _cds() {
     local word="${COMP_WORDS[COMP_CWORD]}"
     # tab completion for 'cds + [tab]', 'cds - [tab]', 'cds + <letter(s)>[tab]', or 'cds - <letter(s)>[tab]', 'cds [tab]', or 'cds <letter(s)>[tab]'
     # is simply the list of current shortcuts
-    if [ "$3" = "-" ] || [ "$3" = "+" ] || ( [ "$1" = "$3" ] && [ "${word/'/'}" = "$word" ] ); then 
+    if [ "$3" = "+" ] || ( [ "$1" = "$3" ] && [ "${word/'/'}" = "$word" ] ); then 
         local temp_reply=( $(compgen -W "$(ls $SHORT_PATH)" -- "$word") )
         # if there isn't anything (like a - or +) in front of the word we are completing
         if [ "$1" = "$3" ]; then
@@ -45,6 +45,11 @@ _cds() {
             temp_reply=( "${temp_reply[@]/%//}" ) # append a slash to cds's completions
         fi
         COMPREPLY+=( "${temp_reply[@]}" )
+    # tab completion for 'cds - [tab]'
+    elif [ "${COMP_WORDS[1]}" = "-" ]; then
+        for shortcut in "${COMP_WORDS[@]:2}"; do
+            echo $shortcut
+        done
     # tab completion for 'cds /[tab]', 'cds <letter(s)>/[tab]', 'cds <letter(s)>/<letter(s)>/[tab], or some variation with a slash
     # needs to go find subdirectories
     elif [ "$1" = "$3" ]; then

--- a/.bash_cds
+++ b/.bash_cds
@@ -37,19 +37,21 @@ _cds() {
     local word="${COMP_WORDS[COMP_CWORD]}"
     # tab completion for 'cds + [tab]', 'cds - [tab]', 'cds + <letter(s)>[tab]', or 'cds - <letter(s)>[tab]', 'cds [tab]', or 'cds <letter(s)>[tab]'
     # is simply the list of current shortcuts
-    if [ "$3" = "+" ] || ( [ "$1" = "$3" ] && [ "${word/'/'}" = "$word" ] ); then 
+    if [ "${COMP_WORDS[1]}" = "-" ] || [ "${COMP_WORDS[1]}" = "+" ] || ( [ "$1" = "$3" ] && [ "${word/'/'}" = "$word" ] ); then 
         local temp_reply=( $(compgen -W "$(ls $SHORT_PATH)" -- "$word") )
         # if there isn't anything (like a - or +) in front of the word we are completing
         if [ "$1" = "$3" ]; then
             _cd
             temp_reply=( "${temp_reply[@]/%//}" ) # append a slash to cds's completions
         fi
+        # if the first parameter to cds is "-"
+        if [ "${COMP_WORDS[1]}" = "-" ]; then
+            # remove any shortcut names that have already been typed from the completions
+            for shortcut in "${COMP_WORDS[@]:2}"; do
+                echo $shortcut
+            done
+        fi
         COMPREPLY+=( "${temp_reply[@]}" )
-    # tab completion for 'cds - [tab]'
-    elif [ "${COMP_WORDS[1]}" = "-" ]; then
-        for shortcut in "${COMP_WORDS[@]:2}"; do
-            echo $shortcut
-        done
     # tab completion for 'cds /[tab]', 'cds <letter(s)>/[tab]', 'cds <letter(s)>/<letter(s)>/[tab], or some variation with a slash
     # needs to go find subdirectories
     elif [ "$1" = "$3" ]; then


### PR DESCRIPTION
In this episode of `cds`'s pull requests:
- I semi-resolve #30 by accounting for tab completions anywhere in a call to `cds -` but not making tab completions smart enough that they won't suggest removing shortcut names that you have already typed.
- I also make sure that the `_cd` function for `cd`'s tab completions is defined before I enable `cds` tab completions (since not all systems have `_cd` defined and it is a dependency of `_cds`). An investigation into how `cd` still enables tab completion on these systems is underway.
- I realize that `cds` doesn't actually need to use realpath. 😅 Unfortunately, `_cds` still does, so we still have a realpath dependency.