### PR TITLE
Fix desk command

### DIFF
--- a/.bash_nav
+++ b/.bash_nav
@@ -7,7 +7,7 @@ if [ -d '/mnt/c/Windows' ]; then
     alias cmd='/mnt/c/Windows/System32/cmd.exe /C'
 
     # wanna go to desktop
-    alias desk='cd /mnt/c/Users/$(cmd "echo | set /p=%USERNAME%")/Desktop'
+    alias desk="cd /mnt/c/Users/$(echo $(cmd "echo | set /p=%USERPROFILE%") | sed 's:.*\\::')/Desktop"
 
     # open windows file manager in the current directory
     alias explorer='/mnt/c/Windows/explorer.exe .'


### PR DESCRIPTION
This fixes issue #42, at least for now.
This certainly makes the desk command more complicated. So if issues with `desk` come up again, we might want to consider getting rid of the command altogether, especially since `cds` is perfect for this sort of stuff.