### PR TITLE
fix an issue with cds tab completion

### DIFF
--- a/.bash_cds
+++ b/.bash_cds
@@ -53,7 +53,7 @@ _cds() {
         # get the absolute path to the shortcut symlink
         local sympath=$($ABSPATH/realpath "$SHORT_PATH/$shortcut")
         # if the user is using a cds shortcut
-        if [ "$shortcut" != "" ] && [ -d "$sympath" ]; then
+        if [ "$shortcut" != "" ] && [ "$shortcut" != ".." ] && [ "$shortcut" != "." ] && [ -d "$sympath" ]; then
             # the absolute path of the text that the user is typing
             totalpath="$sympath/${word#*/}"
             # fake a regular call to _cd. it won't even know the difference ;p


### PR DESCRIPTION
resolve #58 so that tab completion works for `../[tab]` and `./[tab]`

you can delete the fix_cds_tab_complete branch after merging