### PR TITLE
conditional to check shell

### DIFF
--- a/.bash_cds
+++ b/.bash_cds
@@ -69,9 +69,9 @@ _cds() {
         fi
     fi
 }
-# command to enable cds tab-completion
+# command to enable cds tab-completion (only if the shell is bash!)
 # nospace tells it to not put a space afterward
-if test -n "$BASH_VERSION"; then
+if $(which ps) -p $$ | grep "bash" >/dev/null; then
     type _cd  &>/dev/null && complete -o nospace -F _cds cds
 fi
 


### PR DESCRIPTION
This resolves a current bug with how `.bash_cds` detects the current shell. See issue #68 for more details.