### PR TITLE
Add delpermalias command

### DIFF
--- a/.bash_alias
+++ b/.bash_alias
@@ -62,6 +62,16 @@ altalias() {
 	done
 }
 
+delpermalias() {
+	# Unalias for current session.
+	unalias "$1"
+	# Check if the generated file exists
+	if [ -f $ABSPATH/.usr_aliases ]; then
+		# Delete the line in the file that has arg 1, the nickname. 
+		sed "/$1/d" $ABSPATH/.usr_aliases
+	fi
+}
+
 # Include all user-created aliases if the generated file exists. 
 if [ -f $ABSPATH/.usr_aliases ]; then
 	. $ABSPATH/.usr_aliases

--- a/.bash_alias
+++ b/.bash_alias
@@ -68,7 +68,7 @@ delpermalias() {
 	# Check if the generated file exists
 	if [ -f $ABSPATH/.usr_aliases ]; then
 		# Delete the line in the file that has arg 1, the nickname. 
-		sed "/$1/d" $ABSPATH/.usr_aliases
+		sed "/^alias $1=/d" $ABSPATH/.usr_aliases
 	fi
 }
 


### PR DESCRIPTION
Can handily replace the unalias command. Unaliases the passed nickname and then deletes the line with the nickname in it from the `.usr_aliases` file, if it exists. 