### PR TITLE
remove the desk alias

### DIFF
--- a/.bash_nav
+++ b/.bash_nav
@@ -6,9 +6,6 @@ if [ -d '/mnt/c/Windows' ]; then
     # alias cmd for calling the windows command line from bash
     alias cmd='/mnt/c/Windows/System32/cmd.exe /C'
 
-    # wanna go to desktop
-    alias desk="cd /mnt/c/Users/$(echo $(cmd "echo | set /p=%USERPROFILE%") | sed 's:.*\\::')/Desktop"
-
     # open windows file manager in the current directory
     alias explorer='/mnt/c/Windows/explorer.exe .'
 


### PR DESCRIPTION
The `desk` alias has been causing the following error message to be displayed in WSL2 each time the alias is declared (on terminal start-up):
```
'\\wsl$\Ubuntu-18.04\home\amassarat'
CMD.EXE was started with the above path as the current directory.
UNC paths are not supported.  Defaulting to Windows directory.
```
This PR removes the `desk` alias because its functionality can be achieved using `cds`.

Alternatively, if you'd rather keep the alias, the following patch will silence the error:
```
- alias desk="cd /mnt/c/Users/$(echo $(cmd "echo | set /p=%USERPROFILE%") | sed 's:.*\\::')/Desktop"
+ alias desk="cd /mnt/c/Users/$(echo $(2>/dev/null cmd "echo | set /p=%USERPROFILE%") | sed 's:.*\\::')/Desktop"
```