### PR TITLE
new setup script

### DIFF
--- a/.bash_nav
+++ b/.bash_nav
@@ -16,12 +16,9 @@ fi
 
 # Source the base file for whatever shell you're running.
 src() {
-	if [ "$SHELL" = "/bin/bash" ]; then
-		. ~/.bashrc
-		echo "~/.bashrc sourced."
-	elif [ "$SHELL" = "/bin/zsh" ]; then
-		. ~/.zshrc
-		echo "~/.zshrc sourced."
+	local shll="$(basename -- "$SHELL")"
+	if [ "$shll" = "bash" ] || [ "$shll" = "zsh" ] && [ -f "$HOME/.${shll}rc" ]; then
+		. "$HOME/.${shll}rc" && echo "~/.${shll}rc sourced."
 	else
 		echo "Could not source; this shell is not supported."
 	fi

--- a/.bash_nav
+++ b/.bash_nav
@@ -16,6 +16,7 @@ fi
 
 # Source the base file for whatever shell you're running.
 src() {
+	# get basename of default shell in case the shell exec file is not in /bin
 	local shll="$(basename -- "$SHELL")"
 	if [ "$shll" = "bash" ] || [ "$shll" = "zsh" ] && [ -f "$HOME/.${shll}rc" ]; then
 		. "$HOME/.${shll}rc" && echo "~/.${shll}rc sourced."

--- a/setup
+++ b/setup
@@ -1,58 +1,42 @@
 #!/bin/sh
 
-# This is the absolute path to the repo. 
-ABSPATH=$($(dirname "$0")/realpath $(dirname "$0"))
+# This is the absolute path to the repo.
+ABSPATH="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)"
 
 # Handle: given a file as a first argument,
 # include it in a file given as a second arg
 # if it is not already there.
 handle () {
-	if ! grep -Fxq "# myaliases: include $1" "$2"; then # Sorry about this tabbing. 
-		echo "# myaliases: include $1" >> "$2"
+	# check whether we need to locate the true path or use literal $ABSPATH
+	if [ -f "$ABSPATH/$1" ]; then
+		local new_text="\"$ABSPATH/$1\""
+	else
+		local new_text="$1"
+	fi
+	local new_text="test -f $new_text && . $new_text"
+	# make sure that file exists before prepending to it
+	touch "$2"
+	if ! grep -Fxq "$new_text" "$2"; then
 		echo "Including $1."
-		echo "if [ -f $($ABSPATH/realpath "$1") ]; then
-	. $($ABSPATH/realpath "$1")
-fi" >> "$2"
+		echo "$(echo "$new_text" | cat - "$2")" > "$2"
 	fi
 }
 
-# Make sure that included exists before you begin.
-if [ ! -f $ABSPATH/.included ]; then
-	echo "File .included does not exist. Creating."
-	touch $ABSPATH/.included
-	# Set up global var for the path to this directory.
-	echo "ABSPATH=$ABSPATH" >> $ABSPATH/.included
-fi
-
-# Make sure they have a .bash_aliases.
-if [ ! -f ~/.bash_aliases ]; then
-	echo "File .bash_aliases does not exist. Creating."
-	touch ~/.bash_aliases
-fi
-
-FILES="$ABSPATH/.bash_*"
-
 # If there are no arguments, then include all.
-if [ $# = 0 ]; then
-	for f in $FILES
-	do
-		handle "$($ABSPATH/realpath "$f")" "$ABSPATH/.included"
-	done
+if [ $# -eq 0 ]; then
+	FILES="$(cd "$ABSPATH" && echo .bash_*)"
 else
-	# Iterate over arguments. 
-	for arg in "$@"
-	do
-		# Convert to a path, appending .bash_ to each argument.
-		handle "$($ABSPATH/realpath "$ABSPATH/.bash_${arg}")" "$ABSPATH/.included"
-	done
+	FILES="$(echo " $@" | sed 's/ / .bash_/g')"
 fi
+
+for f in "$FILES"; do
+	handle "$f" "$ABSPATH/.included"
+done
+
+# Set up global var for the path to this directory.
+# But first, retrieve the contents of .included without the ABSPATH declaration
+curr_include="$(grep -svx "ABSPATH=.*" "$ABSPATH/.included")"
+echo "$(echo "ABSPATH='$ABSPATH'"; echo "$curr_include")" > "$ABSPATH/.included"
 
 # If .bash_aliases doesn't already include .included, make it do that.
-handle "$ABSPATH/.included" ~/.bash_aliases
-
-# Source the bashrc to save changes. 
-if [ "$SHELL" = "/bin/bash" ]; then
-	. ~/.bashrc
-else
-	echo "We don't currently support your shell. Please source your equivalent of .bashrc on your own."
-fi
+handle "$ABSPATH/.included" "$HOME"/.bash_aliases

--- a/setup
+++ b/setup
@@ -10,14 +10,8 @@ ABSPATH="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)"
 # include it in a file given as a second arg
 # if it is not already there.
 handle () {
-	# check whether we need to locate the true path or use literal $ABSPATH
-	if [ -f "$ABSPATH/$1" ]; then
-		local new_text="\"$ABSPATH/$1\""
-	else
-		local new_text="$1"
-	fi
-	local new_text="test -f $new_text && . $new_text"
-	if [ -z "$(grep -Fsx "$new_text" "$2")" ]; then
+	local new_text="test -f \"$ABSPATH/$1\" && . \"$ABSPATH/$1\""
+	if [ -f "$ABSPATH/$1" ] && [ -z "$(grep -Fsx "$new_text" "$2")" ]; then
 		echo "Including $1."
 		prepend "$2" "$new_text"
 	fi
@@ -34,9 +28,9 @@ for f in "$FILES"; do
 	handle "$f" "$ABSPATH/.included"
 done
 
-# Set up global var for the path to this directory.
-# Use grep to retrieve the contents of .included without the ABSPATH declaration
-echo "$(echo "ABSPATH='$ABSPATH'"; grep -svx "ABSPATH=.*" "$ABSPATH/.included")" > "$ABSPATH/.included"
-
 # If .bash_aliases doesn't already include .included, make it do that.
-handle "$ABSPATH/.included" "$HOME"/.bash_aliases
+handle ".included" "$HOME"/.bash_aliases
+
+# Set up global var for the path to this directory.
+# Use grep to retrieve the contents of .bash_aliases without the ABSPATH declaration
+echo "$(echo "ABSPATH='$ABSPATH'"; grep -svx "ABSPATH=.*" "$HOME"/.bash_aliases)" > "$HOME"/.bash_aliases

--- a/setup
+++ b/setup
@@ -3,14 +3,14 @@
 # This is the absolute path to the repo.
 ABSPATH="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)"
 
-# use the prepend function
+# load the prepend function
 . "$ABSPATH/.bash_subshell"
 
 # Handle: given a file as a first argument,
 # include it in a file given as a second arg
 # if it is not already there.
 handle () {
-	local new_text="test -f \"$ABSPATH/$1\" && . \"$ABSPATH/$1\""
+	local new_text="test -f \"\$ABSPATH/$1\" && . \"\$ABSPATH/$1\""
 	if [ -f "$ABSPATH/$1" ] && [ -z "$(grep -Fsx "$new_text" "$2")" ]; then
 		echo "Including $1."
 		prepend "$2" "$new_text"
@@ -24,7 +24,7 @@ else
 	FILES="$(echo " $@" | sed 's/ / .bash_/g')"
 fi
 
-for f in "$FILES"; do
+for f in $FILES; do
 	handle "$f" "$ABSPATH/.included"
 done
 

--- a/setup
+++ b/setup
@@ -3,6 +3,9 @@
 # This is the absolute path to the repo.
 ABSPATH="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)"
 
+# use the prepend function
+. "$ABSPATH/.bash_subshell"
+
 # Handle: given a file as a first argument,
 # include it in a file given as a second arg
 # if it is not already there.
@@ -14,11 +17,9 @@ handle () {
 		local new_text="$1"
 	fi
 	local new_text="test -f $new_text && . $new_text"
-	# make sure that file exists before prepending to it
-	touch "$2"
-	if ! grep -Fxq "$new_text" "$2"; then
+	if [ -z "$(grep -Fsx "$new_text" "$2")" ]; then
 		echo "Including $1."
-		echo "$(echo "$new_text" | cat - "$2")" > "$2"
+		prepend "$2" "$new_text"
 	fi
 }
 
@@ -34,9 +35,8 @@ for f in "$FILES"; do
 done
 
 # Set up global var for the path to this directory.
-# But first, retrieve the contents of .included without the ABSPATH declaration
-curr_include="$(grep -svx "ABSPATH=.*" "$ABSPATH/.included")"
-echo "$(echo "ABSPATH='$ABSPATH'"; echo "$curr_include")" > "$ABSPATH/.included"
+# Use grep to retrieve the contents of .included without the ABSPATH declaration
+echo "$(echo "ABSPATH='$ABSPATH'"; grep -svx "ABSPATH=.*" "$ABSPATH/.included")" > "$ABSPATH/.included"
 
 # If .bash_aliases doesn't already include .included, make it do that.
 handle "$ABSPATH/.included" "$HOME"/.bash_aliases

--- a/uninstall
+++ b/uninstall
@@ -1,10 +1,9 @@
 #!/bin/sh
 
-repo=$($(dirname "$0")/realpath $(dirname "$0"))
+repo="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)"
 
-# Delete the include lines from ~/.bash_aliases. 
-# Finds comment and deletes 4 lines beginning from that one. 
-printf 'g/^# myaliases/\n.,+3d\nwq\n' | ed -s ~/.bash_aliases > /dev/null 2>&1
+# Delete the include lines from ~/.bash_aliases.
+echo "$(grep -sv "ABSPATH" "$HOME"/.bash_aliases)" > "$HOME"/.bash_aliases
 
 # Delete our generated file.
 rm "$repo/.included"


### PR DESCRIPTION
Note: Make sure you decide whether to merge this before #87.

I wrote this PR primarily to resolve #72, but then things sort of snowballed, and I ended up refactoring a lot of `setup`. Feel free to keep or change code as you please!

Here are the major changes:
- `setup` will prepend to `.bash_aliases` instead of appending to it (see #72 for discussion)
- remove `setup`'s realpath dependency
    See this [discussion](https://stackoverflow.com/a/29835459) for why I don't think we need it.
- `setup` will update `$ABSPATH` if the user decides to change the location of the myaliases directory
    The user should be encouraged to run `setup` every time they move myaliases.
- support for spaces in `$ABSPATH` (although admittedly this isn't tested)
- improve portability
    - for example, I use `$HOME` instead of `~`
- To resolve #80, I deleted the code that would source `~/.bashrc`
    It's impossible to source a file from inside of a script in the way you wanted to, since scripts are executed in subshells. Instead, we can just tell the user to do it themselves, or they can use the `src` command if they feel more comfortable with that. In a way, it's almost better that they handle it themselves because we use `$SHELL` to detect their shell, but `$SHELL` refers to their default shell, not necessarily the one they're currently using.
    By the way, I updated the `src` command to improve portability (since some environments might have their default shell installed locally instead of in `/bin`).

I put portability at the forefront of these changes. The setup/uninstall scripts should now work with any POSIX compatible shells. This is relevant for #28.

This version of `setup` is incompatible with the original. Before trying out the new `setup`, the user should first run the old `uninstall` script.