### PR TITLE
sshfs on wsl2!

### DIFF
--- a/.bash_nav
+++ b/.bash_nav
@@ -19,17 +19,18 @@ if [ -d '/mnt/c/Windows' ]; then
         command -v sshfs >/dev/null 2>&1 || { echo >&2 "error: sshfs is not installed"; return 1; }
         grep -q '^user_allow_other' /etc/fuse.conf || { echo >&2 "error: please uncomment the 'user_allow_other' option in /etc/fuse.conf"; return 1; }
         ssh -q "$1" exit >/dev/null || { echo >&2 "error: cannot connect to '$1' via ssh; check that '$1' is in your ~/.ssh/config"; return 1; }
-        [ -d "${2:-$1}" ] && { ls -1qA "${2:-$1}" | grep -q .; } >/dev/null 2>&1 && { echo >&2 "error: '${2:-$1}' is not an empty directory"; return 1; }
+        [ -d "${2:-$1}" ] && { ls -1qA "${2:-$1}" | grep -q .; } >/dev/null 2>&1 && { echo >&2 "error: '${2:-$1}' is not an empty directory; is it already mounted?"; return 1; }
         # set up a trap to exit the mount before attempting to create it
         trap "cd \"$PWD\" && { fusermount -u \"${2:-$1}\"; rmdir \"${2:-$1}\"; }" EXIT && mkdir -p "${2:-$1}" && {
-            sshfs -o allow_other,reconnect,ServerAliveInterval=15,ServerAliveCountMax=3,cache_timeout=3600,follow_symlinks "$1": "${2:-$1}"
+            # ServerAlive settings prevent the ssh connection from dying unexpectedly
+            # cache_timeout controls the number of seconds before sshfs retrieves new files from the server
+            sshfs -o allow_other,reconnect,ServerAliveInterval=15,ServerAliveCountMax=3,cache_timeout=900,follow_symlinks "$1": "${2:-$1}"
         } || {
             # if the sshfs command didn't work, store the exit code, clean up the dir and the trap, and then return the exit code
             local exit_code=$?
             rmdir "${2:-$1}" && trap - EXIT
             return $exit_code
         }
-        cd "${2:-$1}" # enter the mount
     }
 
 fi

--- a/.bash_nav
+++ b/.bash_nav
@@ -17,6 +17,7 @@ if [ -d '/mnt/c/Windows' ]; then
     sshopen() {
         # perform validation checks, first
         command -v sshfs >/dev/null 2>&1 || { echo >&2 "error: sshfs is not installed"; return 1; }
+        grep -q '^user_allow_other' /etc/fuse.conf || { echo >&2 "error: please uncomment the 'user_allow_other' option in /etc/fuse.conf"; return 1; }
         ssh -q "$1" exit >/dev/null || { echo >&2 "error: cannot connect to '$1' via ssh; check that '$1' is in your ~/.ssh/config"; return 1; }
         [ -d "${2:-$1}" ] && { ls -1qA "${2:-$1}" | grep -q .; } >/dev/null 2>&1 && { echo >&2 "error: '${2:-$1}' is not an empty directory"; return 1; }
         # set up a trap to exit the mount before attempting to create it

--- a/.bash_nav
+++ b/.bash_nav
@@ -11,6 +11,23 @@ if [ -d '/mnt/c/Windows' ]; then
         /mnt/c/Windows/explorer.exe `wslpath -w "$@"`
     }
 
+    # mount a remote drive over ssh in WSL2
+    # arg 1: the hostname of the server, as specified in your ssh config
+    sshopen() {
+        ssh -q "$1" exit >/dev/null || return
+        trap "cd \"$PWD\" && { fusermount -u \"$1\"; rmdir \"$1\"; }" EXIT && mkdir -p "$1" && {
+            if [ -z "$(ls -A "$1")" ]; then
+                sshfs -o allow_other,reconnect,ServerAliveInterval=15,ServerAliveCountMax=3,cache_timeout=3600,follow_symlinks "$1": "$1"
+            fi
+        } || {
+            # if the sshfs command didn't work, store the exit code, clean up the dir and the trap, and then return the exit code
+            local exit_code=$?
+            rmdir "$1" && trap - EXIT
+            return $exit_code
+        }
+        cd "$1"
+    }
+
 fi
 
 # Source the base file for whatever shell you're running.

--- a/.bash_nav
+++ b/.bash_nav
@@ -13,19 +13,22 @@ if [ -d '/mnt/c/Windows' ]; then
 
     # mount a remote drive over ssh in WSL2
     # arg 1: the hostname of the server, as specified in your ssh config
+    # arg 2 (optional): the mount directory; defaults to arg1 in the current directory
     sshopen() {
-        ssh -q "$1" exit >/dev/null || return
-        trap "cd \"$PWD\" && { fusermount -u \"$1\"; rmdir \"$1\"; }" EXIT && mkdir -p "$1" && {
-            if [ -z "$(ls -A "$1")" ]; then
-                sshfs -o allow_other,reconnect,ServerAliveInterval=15,ServerAliveCountMax=3,cache_timeout=3600,follow_symlinks "$1": "$1"
-            fi
+        # perform validation checks, first
+        command -v sshfs >/dev/null 2>&1 || { echo >&2 "error: sshfs is not installed"; return 1; }
+        ssh -q "$1" exit >/dev/null || { echo >&2 "error: cannot connect to '$1' via ssh; check that '$1' is in your ~/.ssh/config"; return 1; }
+        [ -d "${2:-$1}" ] && { ls -1qA "${2:-$1}" | grep -q .; } >/dev/null 2>&1 && { echo >&2 "error: '${2:-$1}' is not an empty directory"; return 1; }
+        # set up a trap to exit the mount before attempting to create it
+        trap "cd \"$PWD\" && { fusermount -u \"${2:-$1}\"; rmdir \"${2:-$1}\"; }" EXIT && mkdir -p "${2:-$1}" && {
+            sshfs -o allow_other,reconnect,ServerAliveInterval=15,ServerAliveCountMax=3,cache_timeout=3600,follow_symlinks "$1": "${2:-$1}"
         } || {
             # if the sshfs command didn't work, store the exit code, clean up the dir and the trap, and then return the exit code
             local exit_code=$?
-            rmdir "$1" && trap - EXIT
+            rmdir "${2:-$1}" && trap - EXIT
             return $exit_code
         }
-        cd "$1"
+        cd "${2:-$1}" # enter the mount
     }
 
 fi


### PR DESCRIPTION
Thanks to WSL2, it's now finally possible to use SSHFS on Windows! This closes #91



<hr id='sshopen_divider'>
<br>
<h3 id='sshopen_command'>sshopen</h3>

Mounts a remote file system over SSH on WSL. Lets you view and edit files on an ssh-accessible server as if they were on your Windows computer.
Unlike `sshfs`, `sshopen` automatically handles the creation and subsequent cleanup of the mount directory.
#### prerequisites
1. The remote server must have [an entry in your `~/.ssh/config`](https://linuxize.com/post/using-the-ssh-config-file/#ssh-config-file-example)
2. [WSL2, not WSL1](https://docs.microsoft.com/en-us/windows/wsl/install-win10#set-your-distribution-version-to-wsl-1-or-wsl-2)
3. [`sshfs` must be installed](https://www.digitalocean.com/community/tutorials/how-to-use-sshfs-to-mount-remote-file-systems-over-ssh#installing-sshfs)
4. The `user_allow_other` config option must be uncommented in `/etc/fuse.conf`
#### usage
```
arg 1: the "Host" alias of the server, as specified in your ssh config
arg 2 (optional): the path to the mount directory; defaults to arg1 in the current directory
```
#### an example
Let's mount our server, knuth.
```
sshopen knuth
```
After mounting the directory, you can also open it in Windows' File Explorer (using `open()` in [`.bash_nav`](https://github.com/GiselleSerate/myaliases/blob/master/.bash_nav)).
```
open knuth
```
#### common issues
- If the remote server lives behind an AnyConnect VPN, the `sshopen` command will fail. You should use [`openconnect`](https://www.infradead.org/openconnect/) to connect to the VPN before using `sshopen`
- If `sshfs` gives `error: fuse: device not found, try 'modprobe fuse' first`, then [you should use WSL2 and not WSL1](https://github.com/microsoft/WSL/issues/4172#issuecomment-520063650)
- Depending on your network connection, `sshopen` might choke on large files. Consider using `scp` for such files, instead.
- In order to reduce network usage, `sshopen` will only retrieve new files from the server every 15 minutes. If you want this to happen more frequently, just change the `cache_timeout` setting in the `sshfs` command.
- The unmount will fail if any processes are still utilizing files in the mount, so you should close Windows File Explorer and any other applications before you close your terminal window. If the unmount fails, you can always just run the unmount commands manually:
    ```
    fusermount -u knuth
    rmdir knuth
    ```